### PR TITLE
Life state check in reposition user action

### DIFF
--- a/addons/KeepRagdollPose/Scripts/Game/ACE_Medical_Reposition/UserActions/ACE_Medical_RepositionUserAction.c
+++ b/addons/KeepRagdollPose/Scripts/Game/ACE_Medical_Reposition/UserActions/ACE_Medical_RepositionUserAction.c
@@ -36,6 +36,9 @@ class ACE_Medical_RepositionUserAction : ScriptedUserAction
 		if (!ownerController)
 			return false;
 		
+		if (ownerController.GetLifeState() == ECharacterLifeState.DEAD)
+			return false;
+		
 		if (!ownerController.IsUnconscious() || ownerController.ACE_Medical_GetUnconsciousPose() == m_eUnconsciousPose)
 			return false;
 		


### PR DESCRIPTION
I noticed that sometimes reposition action is shown on characters that are not alive anymore. This PR adds basic life state check to prevent such situations.